### PR TITLE
Update mighttpd2.cabal

### DIFF
--- a/mighttpd2.cabal
+++ b/mighttpd2.cabal
@@ -53,7 +53,7 @@ Executable mighty
                       , time
                       , transformers
                       , unix
-                      , unix-time
+                      , unix-time >= 0.1.10
                       , unordered-containers
                       , wai >= 1.3
                       , wai-app-file-cgi


### PR DESCRIPTION
Between 0.1.9 and 1.1.10
formatUnixTime went from:
formatUnixTime :: Format -> UnixTime -> ByteString
to
formatUnixTime :: Format -> UnixTime -> IO ByteString

Building with older versions of unix-time gives the error:
src/Report.hs:37:27:
    Couldn't match expected type `IO t0' with actual type`ByteString'
    Expected type: UnixTime -> IO t0
      Actual type: UnixTime -> ByteString
    In the return type of a call of `formatUnixTime'
    In the second argument of`(>>=)', namely
      `formatUnixTime "%d %b %Y %H:%M:%S"'
cabal: Error: some packages failed to install:
mighttpd2-2.8.6 failed during the building phase. The exception was:
ExitFailure 1
