### PR TITLE
mighttpd2.cabal: rename mkindex to 'mighty-mkindex'

### DIFF
--- a/mighttpd2.cabal
+++ b/mighttpd2.cabal
@@ -86,7 +86,7 @@ Executable mighty
                         Utils
                         Paths_mighttpd2
 
-Executable mkindex
+Executable mighty-mkindex
   HS-Source-Dirs:       utils, src
   Main-Is:              mkindex.hs
   GHC-Options:          -Wall


### PR DESCRIPTION
To avoid systemwide installation collision.

mkindex is tool name of commonly used latex package:
[sf] ~:equery b mkindex

> - Searching for mkindex ...
>   app-text/texlive-core-2012-r1 (/usr/bin/mkindex)

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
