### PR TITLE
Fix build failure against recent network update

### DIFF
--- a/src/Net.hs
+++ b/src/Net.hs
@@ -3,7 +3,7 @@ module Net (listenSocket) where
 import Control.Exception
 import Network
 import Network.BSD
-import Network.Socket
+import Network.Socket as NS
 
 listenSocket :: String -> IO Socket
 listenSocket serv = do
@@ -25,4 +25,4 @@ listenSocket' addr = bracketOnError setup cleanup $ \sock -> do
     return sock
  where
    setup = socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
-   cleanup = sClose
+   cleanup = NS.sClose


### PR DESCRIPTION
[13 of 20] Compiling Net              ( src/Net.hs, dist/build/mighty/mighty-tmp/Net.o )

src/Net.hs:28:14:
    Ambiguous occurrence `sClose'
    It could refer to either`Network.sClose',
                             imported from `Network' at src/Net.hs:4:1-14
                          or`Network.Socket.sClose',
                             imported from `Network.Socket' at src/Net.hs:6:1-21

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
