### PR TITLE
mighttpd2.cabal: remove non-existent module

### DIFF
--- a/mighttpd2.cabal
+++ b/mighttpd2.cabal
@@ -89,8 +89,7 @@ Executable mighty
   if flag(tls)
     Build-Depends:      tls
                       , warp-tls >= 3.2 && < 3.3
-  Other-Modules:        Mighty
-                        Server
+  Other-Modules:        Server
                         WaiApp
                         Paths_mighttpd2
 


### PR DESCRIPTION
Currently the entire matrix on Hackage is failing due to this error in mighttpd2.cabal.

See https://matrix.hackage.haskell.org/package/mighttpd2

Thanks to @hvr for this fix.