### PR TITLE
Add conf/example.dhall to release tarball

### DIFF
--- a/mighttpd2.cabal
+++ b/mighttpd2.cabal
@@ -15,7 +15,7 @@ Cabal-Version:          >= 1.10
 Build-Type:             Simple
 Data-Dir:               conf
 Data-Files:             example.conf example.route
-Extra-Source-Files:     Program/Mighty/Dhall/Option.dhall
+Extra-Source-Files:     Program/Mighty/Dhall/Option.dhall conf/example.dhall
 
 Flag tls
   Description:          Support HTTP over TLS (HTTPS).


### PR DESCRIPTION
The test suite is failing without this file:

```
Running 1 test suites...
Test suite spec: RUNNING...

Config
  parseConfig
    parses example.conf correctly [✔]
  parseDhall
    parses example.dhall correctly [✘]
Route
  parseRoute
    parses example.route correctly [✔]

Failures:

  test/ConfigSpec.hs:18:9:
  1) Config.parseDhall parses example.dhall correctly
       uncaught exception: SourcedException

       ↳ ./conf/example.dhall

       Error: Missing file ./conf/example.dhall

       1│ ./conf/example.dhall

       (input):1:1

  To rerun use: --match "/Config/parseDhall/parses example.dhall correctly/"

Randomized with seed 1845430902

Finished in 0.0015 seconds
3 examples, 1 failure

Test suite spec: FAIL
Test suite logged to: dist/test/mighttpd2-4.0.2-spec.log
0 of 1 test suites (0 of 1 test cases) passed.
```