### PR TITLE
Renewing certificates signed by Let's ecnrypt automatically

### DIFF
--- a/src/WaiApp.hs
+++ b/src/WaiApp.hs
@@ -57,7 +57,7 @@ fileCgiApp cspec filespec cgispec revproxyspec rdr req respond
     (host, _) = hostPort req
     rawpath = rawPathInfo req
     path = urlDecode False rawpath
-    dotFile = BS.isPrefixOf "." rawpath || BS.isInfixOf "/." rawpath
+    dotFile = not (BS.isPrefixOf "/.well-known/" rawpath) && (BS.isPrefixOf "." rawpath || BS.isInfixOf "/." rawpath)
     mmp um = case getBlock host um of
         Nothing -> Fail
         Just blk -> getRoute path blk

--- a/utils/renew-cert.sh
+++ b/utils/renew-cert.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+# A shell script for renewing certificates of Let's encrypt.
+
+# Assuming this directory contains everything.
+MIGHTY_PATH=/usr/local/mighty
+
+# sudo certbot renew --webroot -w /usr/local/mighty/webroot --deploy-hook /usr/local/mighty/renew-cert.sh
+
+${MIGHTY_PATH}/mightyctl retire
+${MIGHTY_PATH}/mighty ${MIGHTY_PATH}/conf ${MIGHTY_PATH}/route +RTS -N2


### PR DESCRIPTION
Assuming `/usr/local/mighty/` has everthings.

```
% cd /usr/local/mighty
% ls
mighty*
conf
route
webroot/
renew-cert.sh*
```

Here is an example of crontab to execute `certbot renew` at 8:00 on the 1st of every month:

```
0 8 1 * * /usr/bin/certbot renew --webroot -w /usr/local/mighty/webroot --deploy-hook /usr/local/mighty/renew-cert.sh
```

The contents of `renew-cert.sh` are as follow:

```
MIGHTY_PATH=/usr/local/mighty
${MIGHTY_PATH}/mightyctl retire
${MIGHTY_PATH}/mighty ${MIGHTY_PATH}/conf ${MIGHTY_PATH}/route +RTS -N2
```

In this case, `route` file should have:

```
/.well-known/acme-challenge/ -> /usr/local/mighty/webroot/.well-known/acme-challenge/
```